### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.2-jessie
+FROM python:3.6-stretch
 
 # Install production dependencies.
 ADD requirements.txt /env/requirements.txt


### PR DESCRIPTION
Update base image to Debian stretch (latest release) and remove
patch level from Python version (should automatically update to
patch versions in the 3.6 series when new base images are
pushed to Docker hub).

:hourglass: **Status**: _Open for visibility_
:tickets: **Ticket(s)**: N/A

## :construction_worker: Changes
* Bump base image version to latest Python, Debian

## :flashlight: Testing Instructions
`make && make dev`
