### PR TITLE
Fix A Few Bugs

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -38,10 +38,10 @@ def new_event_dict():
 
 
 @patch('worker.Eventbrite', new=MockEventbrite)
-@patch('worker.load_event.delay')
-def test_fetch_events(mock_load_event_delay):
+@patch('worker.load_event')
+def test_fetch_events(mock_load_event):
     fetch_events(lat=1, lon=2, rad=3)
-    assert mock_load_event_delay.call_count == 5
+    assert mock_load_event.call_count == 5
 
 
 @new_db()

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -91,13 +91,12 @@ def fetch_events(self, lat, lon, rad, **params):
             })
         )
 
-        load_event.delay(new_event)
+        load_event(new_event)
 
     return result
 
 
-@celery.task(bind=True)
-def load_event(self, event_params):
+def load_event(event_params):
     """Loads an event into the Events table.
     Will not clobber existing events.
 


### PR DESCRIPTION
:hourglass: **Status**: _Ready to merge_
:tickets: **Ticket(s)**: None

## :construction_worker: Changes

+ Queuing less tasks concurrently.

## Errors I'm Seeing

+ **Error1**: `sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) FATAL:  too many connections for role "xbrhbkavfkfaip"`.
+ **Error2**: `source=REDIS_URL sample#used_memory_over_limit=1219832.0bytes message=Database memory close to the limit. Please upgrade your database plan or change your maxmemory policy.`

**Problem: If you query our endpoint during a collection period, the DB is overwhelmed with connections and you get a 500.**

## Hypotheses

1. Celery is making a shitload of database connections concurrently. This would be fine if our DB wasn't a baby instance I believe.
2. Celery is queuing too many tasks for our baby Redis instance. 

## 💡  Fixes

- [x] Queue less tasks (this PR is doing that).
- [x] Change Redis cache eviction policy to be more aggressive (did that).
- [ ] Reduce Celery concurrency (probably a good idea anyways - TODO).
- [ ] Use a cron instead of a dedicated worker (limits our task interval to >10mins :-1:).
- [ ] Move to Google Cloud :joy:
