### PR TITLE
Use ON CONFLICT DO UPDATE Postgres Command

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -50,9 +50,9 @@ def test_load_event():
     database.
     """
     event = new_event_dict()
-    load_event(event)
 
     with session_scope() as db_session:
+        load_event(event, db_session)
         result = db_session.query(Event).one()
         assert result.title == event['title']
         assert result.start_time == event['start_time']
@@ -72,12 +72,11 @@ def test_events_dont_get_clobbered():
         db_session.add(Event(**event_with_attendees))
         db_session.commit()
 
-    # Try to inject a vanilla event without attendees.
-    the_same_event = new_event_dict()
-    load_event(the_same_event)
-    
-    # Now check whats in the db.
-    with session_scope() as db_session:
+        # Try to inject a vanilla event without attendees.
+        the_same_event = new_event_dict()
+        load_event(the_same_event, db_session)
+
+        # Now check whats in the db.
         this_id = the_same_event['id']
         result = db_session.query(Event).filter(Event.id == this_id).all()
         assert len(result) == 1

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -38,10 +38,10 @@ def new_event_dict():
 
 
 @patch('worker.Eventbrite', new=MockEventbrite)
-@patch('worker.load_event.delay')
-def test_fetch_events(mock_load_event_delay):
+@patch('worker.load_event')
+def test_fetch_events(mock_load_event):
     fetch_events(lat=1, lon=2, rad=3)
-    assert mock_load_event_delay.call_count == 5
+    assert mock_load_event.call_count == 5
 
 
 @new_db()

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -98,14 +98,21 @@ def fetch_events(self, lat, lon, rad, **params):
     return result
 
 
+# p str(on_conflict_stmt.compile(dialect=psql.dialect()))
 def load_event(event_params, session):
     """Loads an event into the Events table.
-    Will not clobber existing events.
+    Will update events on confict.
 
     Args:
         event (Event): An event.
     """
-    # Basically an ON CONFLICT DO NOTHING statement.
+    # Basic insert statement.
     insert_stmt = psql.insert(Event).values(**event_params)
-    on_conflict_stmt = insert_stmt.on_conflict_do_nothing()
+
+    # Our ON CONFLICT DO UPDATE clause.
+    on_conflict_stmt = insert_stmt.on_conflict_do_update(
+        index_elements=[Event.id],
+        set_=event_params)
+
+    # Add to database.
     session.execute(on_conflict_stmt)

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -25,7 +25,7 @@ def setup_periodic_tasks(sender, **kwargs):
     # https://www.eventbrite.com/developer/v3/api_overview/rate-limits/
     # We get 2000 calls per hour - this is doing 180.
     sender.add_periodic_task(
-        20,
+        config.COLLECTION_INTERVAL,
         fetch_events.s(
             lat=config.VANCOUVER_LAT,
             lon=config.VANCOUVER_LON,
@@ -92,6 +92,7 @@ def fetch_events(self, lat, lon, rad, **params):
                 })
             )
 
+            # Load event into database.
             load_event(new_event, db_session)
 
     return result

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from celery import Celery
 from eventbrite import Eventbrite
-import sqlalchemy
+import sqlalchemy.dialects.postgresql as psql
 
 from beluga.models import Event, session_scope
 from worker import config
@@ -70,41 +70,41 @@ def fetch_events(self, lat, lon, rad, **params):
     result = eb.event_search(**data)
 
     # Produce a new task to load every event.
-    for event in result['events']:
-        start = dt.datetime.strptime(
-            event['start']['utc'],
-            config.EVENTBRITE_DATE_FMT)
+    with session_scope() as db_session:
+        for event in result['events']:
+            start = dt.datetime.strptime(
+                event['start']['utc'],
+                config.EVENTBRITE_DATE_FMT)
 
-        end = dt.datetime.strptime(
-            event['end']['utc'],
-            config.EVENTBRITE_DATE_FMT)
+            end = dt.datetime.strptime(
+                event['end']['utc'],
+                config.EVENTBRITE_DATE_FMT)
 
-        new_event = dict(
-            id=event['id'],
-            title=event['name']['text'],
-            start_time=start,
-            end_time=end,
-            location=json.dumps({
-                "lat": lat,
-                "lon": lon,
-                "venue_id": event['venue_id']
-            })
-        )
+            new_event = dict(
+                id=event['id'],
+                title=event['name']['text'],
+                start_time=start,
+                end_time=end,
+                location=json.dumps({
+                    "lat": lat,
+                    "lon": lon,
+                    "venue_id": event['venue_id']
+                })
+            )
 
-        load_event(new_event)
+            load_event(new_event, db_session)
 
     return result
 
 
-def load_event(event_params):
+def load_event(event_params, session):
     """Loads an event into the Events table.
     Will not clobber existing events.
 
     Args:
         event (Event): An event.
     """
-    try:
-        with session_scope() as db_session:
-            db_session.add(Event(**event_params))
-    except sqlalchemy.exc.IntegrityError:
-        pass
+    # Basically an ON CONFLICT DO NOTHING statement.
+    insert_stmt = psql.insert(Event).values(**event_params)
+    on_conflict_stmt = insert_stmt.on_conflict_do_nothing()
+    session.execute(on_conflict_stmt)

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -98,7 +98,6 @@ def fetch_events(self, lat, lon, rad, **params):
     return result
 
 
-# p str(on_conflict_stmt.compile(dialect=psql.dialect()))
 def load_event(event_params, session):
     """Loads an event into the Events table.
     Will update events on confict.

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -103,7 +103,8 @@ def load_event(event_params, session):
     Will update events on confict.
 
     Args:
-        event (Event): An event.
+        event_params (dict): A set of event parameters.
+        session (sa.scoped_session): A SQLAlchemy session.
     """
     # Basic insert statement.
     insert_stmt = psql.insert(Event).values(**event_params)

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -91,13 +91,12 @@ def fetch_events(self, lat, lon, rad, **params):
             })
         )
 
-        load_event.delay(new_event)
+        load_event(new_event)
 
     return result
 
 
-@celery.task(bind=True)
-def load_event(self, event_params):
+def load_event(event_params):
     """Loads an event into the Events table.
     Will not clobber existing events.
 

--- a/worker/config.py
+++ b/worker/config.py
@@ -13,3 +13,4 @@ CELERY_BROKER_URL = os.environ['CELERY_BROKER_URL']
 # Eventbrite things.
 EVENTBRITE_APP_KEY = os.environ['EVENTBRITE_APP_KEY']
 EVENTBRITE_DATE_FMT = '%Y-%m-%dT%H:%M:%SZ'  # utc format only.
+COLLECTION_INTERVAL = int(os.environ.get('COLLECTION_INTERVAL', 20))


### PR DESCRIPTION
:hourglass: **Status**: _Ready for review_
:tickets: **Ticket(s)**: None

## :construction_worker: Changes

Added Postgres `ON CONFLICT DO UPDATE` statement to worker semantics.

### Desired Semantics

1. Collect batch of events from eventbrite.
2. Try to insert them individually (do not kick off new tasks for this as our redis instance is still overwhelmed).
3. If there is a conflict on event id => we're trying to update an eventbrite event we've already collected, handle the conflict by updating with new information from this new record.

**Resulting statement**:

```
'INSERT INTO events (id, start_time, end_time, location, title) VALUES (%(id)s, %(start_time)s, %(end_time)s, %(location)s, %(title)s) ON CONFLICT (id) DO UPDATE SET id = %(param_1)s, start_time = %(param_2)s, end_time = %(param_3)s, location = %(param_4)s, title = %(param_5)s'
```

## :flashlight: Testing Instructions

```pytest
docker-compose run test pytest -vvv
```

Run the tests, believe the tests.