### PR TITLE
Bootstrap PostGIS/GeoAlchemy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 script:
-  - docker-compose run test pytest -vvv
+  - docker-compose run test ./bin/test-entrypoint.sh
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,8 @@
 FROM python:3.6-stretch
 
+# Install psql client.
+RUN apt-get update && apt-get install -y postgresql
+
 # Install production dependencies.
 ADD requirements.txt /env/requirements.txt
 RUN pip install -r /env/requirements.txt

--- a/beluga/models.py
+++ b/beluga/models.py
@@ -3,6 +3,7 @@ import os
 
 from contextlib import contextmanager
 
+from geoalchemy2 import Geography
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -81,7 +82,7 @@ class Event(Base):
     start_time_local = sa.Column(sa.types.DateTime())
     end_time_local = sa.Column(sa.types.DateTime())
     timezone = sa.Column(sa.String(50))
-    location = sa.Column(sa.types.JSON)
+    location = sa.Column(Geography('POINT', srid=4326))
     title = sa.Column(sa.String(200))
     attendees = sa.Column(sa.types.JSON)
     capacity = sa.Column(sa.Integer())

--- a/beluga/util.py
+++ b/beluga/util.py
@@ -1,0 +1,9 @@
+from shapely import wkb
+
+
+def wkt_to_location(wkt_obj):
+    """Converts a Well-Known Text element
+    (WKTElement) to a location with parameters
+    x and y.
+    """
+    return wkb.loads(bytes(wkt_obj.data))

--- a/bin/test-entrypoint.sh
+++ b/bin/test-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Script stalls dev container until db comes up.
+
+RET=1
+echo "Waiting for database"
+while ! pg_isready -h postgres -d beluga -U beluga; do
+    sleep 10;
+    echo "DB Not yet up."
+done
+
+# Run tests.
+pytest -vvv

--- a/bin/webdev-entrypoint.sh
+++ b/bin/webdev-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Script stalls dev container until db comes up.
+
+RET=1
+echo "Waiting for database"
+while ! pg_isready -h postgres -d beluga -U beluga; do
+    sleep 10;
+    echo "DB Not yet up."
+done
+
+# Boot app for development.
+gunicorn --reload \
+    --bind \
+    0.0.0.0:8080 \
+    --worker-class \
+    sanic_gunicorn.Worker \
+    beluga:app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.web
-    command: [
-      "gunicorn", "--reload", "--bind", 
-      "0.0.0.0:8080", "--worker-class",
-      "sanic_gunicorn.Worker", "beluga:app"
-    ]
+    command: ./bin/webdev-entrypoint.sh
     ports:
       - "8080:8080"
     volumes:
@@ -22,7 +18,7 @@ services:
       - worker
 
   postgres:
-    image: postgres
+    image: openmaptiles/postgis
     ports:
       - "5432"
     environment:
@@ -49,9 +45,6 @@ services:
       EVENTBRITE_APP_KEY: ${EVENTBRITE_APP_KEY}
       DATABASE_URL: postgres://beluga:beluga@postgres:5432/beluga
       COLLECTION_INTERVAL: 20
-    depends_on:
-      - redis
-      - postgres
     depends_on:
       - postgres
       - redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ sanic-gunicorn==0.1.2
 aiohttp==2.2.5
 sqlalchemy==1.1.14
 psycopg2==2.7.3.1
+geoalchemy2==0.4.0
+shapely==1.6.1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.6-stretch
 
+# Install psql client.
+RUN apt-get update && apt-get install -y postgresql
+
 # Install production dependencies.
 ADD requirements.txt /env/requirements.txt
 ADD worker/requirements.txt /env/requirements-worker.txt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 freezegun==0.3.9
 pytest==3.2.2
+ipdb

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,7 @@
 import datetime as dt
 
+from geoalchemy2 import WKTElement
+
 from beluga.models import Event, session_scope
 from tests.utils import new_db
 
@@ -10,11 +12,7 @@ def test_write_event():
         title='So much good stuff',
         start_time=dt.datetime(2016, 5, 5, 1, 2),
         end_time=dt.datetime(2016, 5, 5, 1, 7),
-        location={
-            'lat': 1, 
-            'lon': 2, 
-            'title': 'location title'
-        }
+        location=WKTElement('POINT(1 2)', srid=4326)
     )
 
     with session_scope() as db_session:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,10 +1,13 @@
 import datetime as dt
-from freezegun import freeze_time
 import json
 import os
 from unittest.mock import patch
 
+from freezegun import freeze_time
+from geoalchemy2 import WKTElement, func
+
 from beluga.models import Event, session_scope
+from beluga.util import wkt_to_location
 import worker as tasks
 from tests import FIXTURES_DIR
 from tests.utils import new_db
@@ -37,11 +40,7 @@ def new_event_dict():
         title='So much good stuff',
         start_time=dt.datetime(2016, 5, 5, 1, 2),
         end_time=dt.datetime(2016, 5, 5, 1, 7),
-        location={
-            'lat': 1,
-            'lon': 2,
-            'title': 'location title'
-        }
+        location=WKTElement('POINT(1 2)', srid=4326)
     )
 
 
@@ -65,7 +64,12 @@ def test_load_event():
         assert result.title == event['title']
         assert result.start_time == event['start_time']
         assert result.end_time == event['end_time']
-        assert result.location == event['location']
+
+        # Location is Well-Known Binary result (Postgis).
+        loc = wkt_to_location(result.location)
+        lat, lon = (float(i) for i in event['location'].data if i.isdigit())
+        assert loc.x == lat
+        assert loc.y == lon
 
 
 @new_db()

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -4,6 +4,7 @@ import logging
 from celery import Celery
 from celery.schedules import crontab
 from eventbrite import Eventbrite
+from geoalchemy2 import WKTElement
 import sqlalchemy.dialects.postgresql as psql
 
 from beluga.models import Event, session_scope
@@ -88,11 +89,10 @@ def fetch_events(self, lat, lon, rad, **params):
                 end_time_local=event['end']['local'],
                 timezone=event['start']['timezone'],
                 capacity=event['capacity'],
-                location={
-                    "lat": venue['latitude'],
-                    "lon": venue['longitude'],
-                    "venue_id": event['venue_id']
-                },
+                location=WKTElement('POINT({} {})'.format(
+                    venue['latitude'],
+                    venue['longitude']
+                ), srid=4326),
                 logo=event['logo'],
                 url=event['url'],
                 description_text=event['description']['text'],

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -4,3 +4,5 @@ redis==2.10.6
 sanic==0.6.0
 sqlalchemy==1.1.14
 psycopg2==2.7.3.1
+geoalchemy2==0.4.0
+shapely==1.6.1


### PR DESCRIPTION
:hourglass: **Status**: _Blocked by #50_
:tickets: **Ticket(s)**: None

## :construction_worker: Changes

+ Bootstrap our GeoAlchemy and PostGIS settings.
+ This slightly complicates our dev environment, the web container needs to wait a moment longer for the PostGIS instance to come up, so it spins for a few seconds (see `webdev-entrypoint.sh`).
+ When testing, a nice workflow is `docker-compose run test bash`.
    + From inside the container, run `pytest tests/test_tasks.py` or whatever to run your test.
    + The entire repo is mounted, so edit whatever you like.
    + You will need to wait a moment for the PostGIS instance to come up.

## :flashlight: Testing Instructions

```bash
docker-compose run test bash
pytest -vvv
```

## Note

+ The event location comes back as null. Need to write `routes.event_handler` before merging this.

```bash
      Column      |            Type             |                      Modifiers                      | Storage  | Stats target | Description
------------------+-----------------------------+-----------------------------------------------------+----------+--------------+-------------
 id               | bigint                      | not null default nextval('events_id_seq'::regclass) | plain    |              |
 start_time       | timestamp without time zone |                                                     | plain    |              |
 end_time         | timestamp without time zone |                                                     | plain    |              |
 start_time_local | timestamp without time zone |                                                     | plain    |              |
 end_time_local   | timestamp without time zone |                                                     | plain    |              |
 timezone         | character varying(50)       |                                                     | extended |              |
 location         | geography(Point,4326)       |                                                     | main     |              |
 title            | character varying(200)      |                                                     | extended |              |
 attendees        | json                        |                                                     | extended |              |
 capacity         | integer                     |                                                     | plain    |              |
 logo             | json                        |                                                     | extended |              |
 url              | character varying(200)      |                                                     | extended |              |
 description_text | text                        |                                                     | extended |              |
 description_html | text                        |                                                     | extended |              |
 is_free          | boolean                     |                                                     | plain    |              |
 online_event     | boolean                     |                                                     | plain    |              |
```